### PR TITLE
Recommending the use of rvm for installation in newer systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@ Device monitoring and control API.
 
 ## Requirements
 
-Devices API is tested against MRI 1.9.3.
+Devices API is tested against MRI 1.9.3. Use [rvm](https://rvm.io/) to maintain a consistent MRI 1.9.3 environment in systems like Ubuntu 16.04/16.10 etc.
 
 
 ## Installation 
 
 ```bash
 $ git clone git@github.com:lelylan/devices.git && cd devices
+$ \curl -sSL https://get.rvm.io | bash -s stable
+$ rvm install 1.9.3-p194
+$ rvm 1.9.3-p194
 $ gem install bundler
 $ bundle install 
 $ foreman start


### PR DESCRIPTION
I was not able to install devices on my Ubuntu 16.10 system because "bundle install" was not able to install packages like "nokogiri" due to a conflict in the version of language installed in the system.

It would be recommended to use a virtual environment set to the version of ruby we are using. I was able to install and run devices after using rvm for the purpose. I have updated the details in the Readme.md file. 